### PR TITLE
bin/magento setup:di:compile breaks due to wrong SearchResultsInterface

### DIFF
--- a/src/Umc/MagentoBundle/Resources/views/source/Api/Data/_Entity_SearchResultsInterface.php.html.twig
+++ b/src/Umc/MagentoBundle/Resources/views/source/Api/Data/_Entity_SearchResultsInterface.php.html.twig
@@ -8,7 +8,7 @@ use Magento\Framework\Api\SearchCriteriaInterface;
 /**
  * @api
  */
-interface {{ entity.getNameSingular()|camel|ucfirst }}SearchResultInterface
+interface {{ entity.getNameSingular()|camel|ucfirst }}SearchResultsInterface
 {
     /**
      * get items

--- a/src/Umc/MagentoBundle/Resources/views/source/Model/_Entity_SearchResults.php.html.twig
+++ b/src/Umc/MagentoBundle/Resources/views/source/Model/_Entity_SearchResults.php.html.twig
@@ -8,7 +8,7 @@ use Magento\Framework\Api\SearchResults;
 use {{ entity.getSearchResultsInterface() }};
 {{ sortEnd() }}
 
-class {{ entity.getNameSingular()|camel|ucfirst }}SearchResults extends SearchResults implements {{ entity.getNameSingular()|camel|ucfirst }}SearchResultInterface
+class {{ entity.getNameSingular()|camel|ucfirst }}SearchResults extends SearchResults implements {{ entity.getNameSingular()|camel|ucfirst }}SearchResultsInterface
 {
 
 }


### PR DESCRIPTION
…ity_SearchResultsInterface.php.html.twig

bin/magento setup:di:compile breaks compilation due to wrong Interface class name.

If I edit my FooSearchResultInterface class to FooSearchResult**s**Interface and also edit FooSearchResults use references compilation works well.